### PR TITLE
Entity properties refactor

### DIFF
--- a/src/EntityServer.ts
+++ b/src/EntityServer.ts
@@ -127,8 +127,8 @@ class EntityServer extends AssignmentClient {
     /*@sdkdoc
      *  Triggered when new or changed entity data is received from the entity server.
      *  @callback EntityServer~entityData
-     *  @param {EntityDataDetails[]} entityData - The entity data for one or more entities. Note that complete entity data is
-     *  provided for both new and changed entities.
+     *  @param {EntityProperties[]} entityData - The entity properties for one or more entities. Note that complete entity
+     *      properties are provided for both new and changed entities.
      */
     get entityData(): Signal {
         return this.#_entityData.signal();

--- a/src/domain/entities/ModelEntityItem.ts
+++ b/src/domain/entities/ModelEntityItem.ts
@@ -9,6 +9,7 @@
 //  See the accompanying file LICENSE or http://www.apache.org/licenses/LICENSE-2.0.html
 //
 
+import { CommonEntityProperties } from "../networking/packets/EntityData";
 import UDT from "../networking/udt/UDT";
 import type { color } from "../shared/Color";
 import GLMHelpers from "../shared/GLMHelpers";
@@ -30,7 +31,7 @@ type AnimationProperties = {
     animationHold: boolean | undefined;
 };
 
-type ModelEntityProperties = {
+type ModelEntitySubclassProperties = {
     shapeType: number | undefined;
     compoundShapeURL: string | undefined;
     color: color | undefined;
@@ -48,9 +49,11 @@ type ModelEntityProperties = {
     animation: AnimationProperties | undefined;
 };
 
+type ModelEntityProperties = CommonEntityProperties & ModelEntitySubclassProperties;
+
 type ModelEntitySubclassData = {
     bytesRead: number;
-    properties: ModelEntityProperties;
+    properties: ModelEntitySubclassProperties;
 };
 
 
@@ -81,9 +84,9 @@ class ModelEntityItem {
      */
 
     /*@sdkdoc
-     * The Model {@link EntityType|entity type} displays a glTF, FBX, or OBJ model. When adding an entity, if no
-     *     <code>dimensions</code> value is specified then the model is automatically sized to its natural dimensions. It has
-     *     properties in addition to the common {@link EntityProperties}.
+     *  The Model {@link EntityType|entity type} displays a glTF, FBX, or OBJ model. When adding an entity, if no
+     *  <code>dimensions</code> value is specified then the model is automatically sized to its natural dimensions. It has
+     *  properties in addition to the common {@link EntityProperties}.
      *  @typedef {object} ModelEntityProperties
      *  @property {number | undefined} shapeType - The shape of the collision hull used if collisions are enabled.
      *  @property {string | undefined} compoundShapeURL - The model file to use for the compound shape if shapeType is
@@ -407,4 +410,4 @@ class ModelEntityItem {
 }
 
 export default ModelEntityItem;
-export type { ModelEntitySubclassData, AnimationProperties };
+export type { ModelEntitySubclassData, ModelEntityProperties, AnimationProperties };

--- a/src/domain/entities/ShapeEntityItem.ts
+++ b/src/domain/entities/ShapeEntityItem.ts
@@ -9,6 +9,7 @@
 //  See the accompanying file LICENSE or http://www.apache.org/licenses/LICENSE-2.0.html
 //
 
+import { CommonEntityProperties } from "../networking/packets/EntityData";
 import UDT from "../networking/udt/UDT";
 import type { color } from "../shared/Color";
 import PropertyFlags from "../shared/PropertyFlags";
@@ -57,15 +58,17 @@ enum Shape {
     TRIANGLE = "Triangle"
 }
 
-type ShapeEntityProperties = {
+type ShapeEntitySubclassProperties = {
     shape: Shape | undefined;
     color: color | undefined;
     alpha: number | undefined;
 };
 
+type ShapeEntityProperties = CommonEntityProperties & ShapeEntitySubclassProperties;
+
 type ShapeEntitySubclassData = {
     bytesRead: number;
-    properties: ShapeEntityProperties;
+    properties: ShapeEntitySubclassProperties;
 };
 
 
@@ -86,7 +89,7 @@ class ShapeEntityItem {
 
     /*@sdkdoc
      *  The Shape {@link EntityType|entity type} displays an entity of a specified shape. It has properties in addition to the
-     *      common {@link EntityProperties}.
+     *  common {@link EntityProperties}.
      *  @typedef {object} ShapeEntityProperties
      *  @property {Shape | undefined} shape - The shape of the entity.
      *  @property {color | undefined} color - The color of the entity.
@@ -167,4 +170,4 @@ class ShapeEntityItem {
 }
 
 export default ShapeEntityItem;
-export type { ShapeEntitySubclassData, Shape };
+export type { ShapeEntitySubclassData, ShapeEntityProperties, Shape };

--- a/src/domain/octree/OctreePacketProcessor.ts
+++ b/src/domain/octree/OctreePacketProcessor.ts
@@ -75,7 +75,7 @@ class OctreePacketProcessor {
     /*@devdoc
      *  Triggered when an entity data packet is received.
      *  @callback OctreePacketProcessor.entityData
-     *  @param {EntityDataDetails[]} entityData - The entity data for one or more entities.
+     *  @param {PacketScribe.EntityDataDetails} entityData - The entity data for one or more entities.
      *  @returns {Signal}
      */
     get entityData(): Signal {

--- a/tests/domain/networking/packets/EntityData.unit.test.js
+++ b/tests/domain/networking/packets/EntityData.unit.test.js
@@ -16,6 +16,7 @@ import Uuid from "../../../../src/domain/shared/Uuid";
 describe("EntityData - unit tests", () => {
 
     /* eslint-disable @typescript-eslint/no-magic-numbers */
+    /* eslint-disable @typescript-eslint/no-unsafe-member-access */
 
     test("Can read a Model entity in a packet", () => {
         // eslint-disable-next-line max-len

--- a/tests/domain/networking/packets/EntityData.unit.test.js
+++ b/tests/domain/networking/packets/EntityData.unit.test.js
@@ -93,7 +93,7 @@ describe("EntityData - unit tests", () => {
         expect(info[0].equippableRightRotationOffset.y).toBeCloseTo(-0.0000152588, 8);
         expect(info[0].equippableRightRotationOffset.z).toBeCloseTo(-0.0000152588, 8);
         expect(info[0].equippableRightRotationOffset.w).toBeCloseTo(1, 2);
-        expect(info[0].equippableIndicatorUrl).toBeUndefined();
+        expect(info[0].equippableIndicatorURL).toBeUndefined();
         expect(info[0].equippableIndicatorScale.x).toBeCloseTo(1, 2);
         expect(info[0].equippableIndicatorScale.y).toBeCloseTo(1, 2);
         expect(info[0].equippableIndicatorScale.z).toBeCloseTo(1, 2);
@@ -128,7 +128,7 @@ describe("EntityData - unit tests", () => {
         expect(info[0].cloneLimit).toBeCloseTo(0, 2);
         expect(info[0].cloneDynamic).toBe(false);
         expect(info[0].cloneAvatarIdentity).toBe(false);
-        expect(info[0].cloneOriginId).toBeUndefined();
+        expect(info[0].cloneOriginID).toBeUndefined();
         expect(info[0].script).toBeUndefined();
         expect(info[0].scriptTimestamp).toBe(0n);
         expect(info[0].serverScripts).toBeUndefined();
@@ -145,7 +145,7 @@ describe("EntityData - unit tests", () => {
         expect(info[0].certificateType).toBeUndefined();
         expect(info[0].staticCertificateVersion).toBe(0);
         expect(info[0].shapeType).toBe(0);
-        expect(info[0].compoundShapeUrl).toBeUndefined();
+        expect(info[0].compoundShapeURL).toBeUndefined();
         expect(info[0].color.red).toBe(255);
         expect(info[0].color.green).toBe(255);
         expect(info[0].color.blue).toBe(255);
@@ -164,7 +164,7 @@ describe("EntityData - unit tests", () => {
         expect(info[0].groupCulled).toBe(false);
         expect(info[0].blendShapeCoefficients).toBe("{\n}\n");
         expect(info[0].useOriginalPivot).toBe(true);
-        expect(info[0].animation.animationUrl).toBeUndefined();
+        expect(info[0].animation.animationURL).toBeUndefined();
         expect(info[0].animation.animationAllowTranslation).toBe(false);
         expect(info[0].animation.animationFPS).toBeCloseTo(30, 2);
         expect(info[0].animation.animationFrameIndex).toBeCloseTo(0, 2);
@@ -228,7 +228,7 @@ describe("EntityData - unit tests", () => {
         expect(info[0].equippableLeftRotationOffset).toBeUndefined();
         expect(info[0].equippableRightPositionOffset).toBeUndefined();
         expect(info[0].equippableRightRotationOffset).toBeUndefined();
-        expect(info[0].equippableIndicatorUrl).toBeUndefined();
+        expect(info[0].equippableIndicatorURL).toBeUndefined();
         expect(info[0].equippableIndicatorScale).toBeUndefined();
         expect(info[0].equippableIndicatorOffset).toBeUndefined();
         expect(info[0].density).toBeUndefined();
@@ -255,7 +255,7 @@ describe("EntityData - unit tests", () => {
         expect(info[0].cloneLimit).toBeCloseTo(0, 2);
         expect(info[0].cloneDynamic).toBe(false);
         expect(info[0].cloneAvatarIdentity).toBe(false);
-        expect(info[0].cloneOriginId).toBeUndefined();
+        expect(info[0].cloneOriginID).toBeUndefined();
         expect(info[0].script).toBeUndefined();
         expect(info[0].scriptTimestamp).toBe(0n);
         expect(info[0].serverScripts).toBeUndefined();
@@ -272,7 +272,7 @@ describe("EntityData - unit tests", () => {
         expect(info[0].certificateType).toBeUndefined();
         expect(info[0].staticCertificateVersion).toBe(0);
         expect(info[0].shapeType).toBe(0);
-        expect(info[0].compoundShapeUrl).toBeUndefined();
+        expect(info[0].compoundShapeURL).toBeUndefined();
         expect(info[0].color.red).toBe(255);
         expect(info[0].color.green).toBe(255);
         expect(info[0].color.blue).toBe(255);
@@ -291,7 +291,7 @@ describe("EntityData - unit tests", () => {
         expect(info[0].groupCulled).toBe(false);
         expect(info[0].blendShapeCoefficients).toBe("{\n}\n");
         expect(info[0].useOriginalPivot).toBe(true);
-        expect(info[0].animation.animationUrl).toBeUndefined();
+        expect(info[0].animation.animationURL).toBeUndefined();
         expect(info[0].animation.animationAllowTranslation).toBe(false);
         expect(info[0].animation.animationFPS).toBeCloseTo(30, 2);
         expect(info[0].animation.animationFrameIndex).toBeCloseTo(0, 2);
@@ -366,7 +366,7 @@ describe("EntityData - unit tests", () => {
         expect(info[1].equippableRightRotationOffset.y).toBeCloseTo(-0.0000152588, 8);
         expect(info[1].equippableRightRotationOffset.z).toBeCloseTo(-0.0000152588, 8);
         expect(info[1].equippableRightRotationOffset.w).toBeCloseTo(1, 2);
-        expect(info[1].equippableIndicatorUrl).toBeUndefined();
+        expect(info[1].equippableIndicatorURL).toBeUndefined();
         expect(info[1].equippableIndicatorScale.x).toBeCloseTo(1, 2);
         expect(info[1].equippableIndicatorScale.y).toBeCloseTo(1, 2);
         expect(info[1].equippableIndicatorScale.z).toBeCloseTo(1, 2);
@@ -401,7 +401,7 @@ describe("EntityData - unit tests", () => {
         expect(info[1].cloneLimit).toBeCloseTo(0, 2);
         expect(info[1].cloneDynamic).toBe(false);
         expect(info[1].cloneAvatarIdentity).toBe(false);
-        expect(info[1].cloneOriginId).toBeUndefined();
+        expect(info[1].cloneOriginID).toBeUndefined();
         expect(info[1].script).toBeUndefined();
         expect(info[1].scriptTimestamp).toBe(0n);
         expect(info[1].serverScripts).toBeUndefined();
@@ -418,7 +418,7 @@ describe("EntityData - unit tests", () => {
         expect(info[1].certificateType).toBeUndefined();
         expect(info[1].staticCertificateVersion).toBe(0);
         expect(info[1].shapeType).toBe(0);
-        expect(info[1].compoundShapeUrl).toBeUndefined();
+        expect(info[1].compoundShapeURL).toBeUndefined();
         expect(info[1].color.red).toBe(255);
         expect(info[1].color.green).toBe(255);
         expect(info[1].color.blue).toBe(255);
@@ -437,7 +437,7 @@ describe("EntityData - unit tests", () => {
         expect(info[1].groupCulled).toBe(false);
         expect(info[1].blendShapeCoefficients).toBe("{\n}\n");
         expect(info[1].useOriginalPivot).toBe(true);
-        expect(info[1].animation.animationUrl).toBeUndefined();
+        expect(info[1].animation.animationURL).toBeUndefined();
         expect(info[1].animation.animationAllowTranslation).toBe(false);
         expect(info[1].animation.animationFPS).toBeCloseTo(30, 2);
         expect(info[1].animation.animationFrameIndex).toBeCloseTo(0, 2);
@@ -522,7 +522,7 @@ describe("EntityData - unit tests", () => {
         expect(info[0].equippableRightRotationOffset.x).toBeCloseTo(-0.000015, 6);
         expect(info[0].equippableRightRotationOffset.y).toBeCloseTo(-0.000015, 6);
         expect(info[0].equippableRightRotationOffset.z).toBeCloseTo(-0.000015, 6);
-        expect(info[0].equippableIndicatorUrl).toBeUndefined();
+        expect(info[0].equippableIndicatorURL).toBeUndefined();
         expect(info[0].equippableIndicatorScale.x).toBe(1);
         expect(info[0].equippableIndicatorScale.y).toBe(1);
         expect(info[0].equippableIndicatorScale.z).toBe(1);
@@ -557,7 +557,7 @@ describe("EntityData - unit tests", () => {
         expect(info[0].cloneLimit).toBeCloseTo(0, 2);
         expect(info[0].cloneDynamic).toBe(false);
         expect(info[0].cloneAvatarIdentity).toBe(false);
-        expect(info[0].cloneOriginId).toBeUndefined();
+        expect(info[0].cloneOriginID).toBeUndefined();
         expect(info[0].script).toBeUndefined();
         expect(info[0].scriptTimestamp).toBe(0n);
         expect(info[0].serverScripts).toBeUndefined();
@@ -574,7 +574,7 @@ describe("EntityData - unit tests", () => {
         expect(info[0].certificateType).toBeUndefined();
         expect(info[0].staticCertificateVersion).toBe(0);
         expect(info[0].shapeType).toBe(0);
-        expect(info[0].compoundShapeUrl).toBeUndefined();
+        expect(info[0].compoundShapeURL).toBeUndefined();
         expect(info[0].color.red).toBe(255);
         expect(info[0].color.green).toBe(255);
         expect(info[0].color.blue).toBe(255);
@@ -593,7 +593,7 @@ describe("EntityData - unit tests", () => {
         expect(info[0].groupCulled).toBe(false);
         expect(info[0].blendShapeCoefficients).toBe("{\n}\n");
         expect(info[0].useOriginalPivot).toBe(true);
-        expect(info[0].animation.animationUrl).toBeUndefined();
+        expect(info[0].animation.animationURL).toBeUndefined();
         expect(info[0].animation.animationAllowTranslation).toBe(false);
         expect(info[0].animation.animationFPS).toBeCloseTo(30, 2);
         expect(info[0].animation.animationFrameIndex).toBeCloseTo(0, 2);
@@ -668,7 +668,7 @@ describe("EntityData - unit tests", () => {
         expect(info[1].equippableRightRotationOffset.y).toBeCloseTo(-0.0000152588, 8);
         expect(info[1].equippableRightRotationOffset.z).toBeCloseTo(-0.0000152588, 8);
         expect(info[1].equippableRightRotationOffset.w).toBeCloseTo(1, 2);
-        expect(info[1].equippableIndicatorUrl).toBeUndefined();
+        expect(info[1].equippableIndicatorURL).toBeUndefined();
         expect(info[1].equippableIndicatorScale.x).toBeCloseTo(1, 2);
         expect(info[1].equippableIndicatorScale.y).toBeCloseTo(1, 2);
         expect(info[1].equippableIndicatorScale.z).toBeCloseTo(1, 2);
@@ -703,7 +703,7 @@ describe("EntityData - unit tests", () => {
         expect(info[1].cloneLimit).toBeCloseTo(0, 2);
         expect(info[1].cloneDynamic).toBe(false);
         expect(info[1].cloneAvatarIdentity).toBe(false);
-        expect(info[1].cloneOriginId).toBeUndefined();
+        expect(info[1].cloneOriginID).toBeUndefined();
         expect(info[1].script).toBeUndefined();
         expect(info[1].scriptTimestamp).toBe(0n);
         expect(info[1].serverScripts).toBeUndefined();


### PR DESCRIPTION
This revises how entity properties are handled taking into consideration the internal SDK code, its use by TypeScript and JavaScript apps, and the SDK doc.

The disabling of the ESLint warning in the unit test is reasonable, I think, given that JavaScript type checking has limitations.
If the unit test is changed to be TypeScript, the type handling works  - e.g., replace the following two lines with those in the comment:
![image](https://user-images.githubusercontent.com/7455448/179325667-1ee39827-1166-459f-a14e-efa761701eb8.png)
